### PR TITLE
Change ISensorFactory registration to scoped lifetime

### DIFF
--- a/src/myNOC.WeatherLink/IServiceCollectionExtensions.cs
+++ b/src/myNOC.WeatherLink/IServiceCollectionExtensions.cs
@@ -28,10 +28,9 @@ namespace myNOC.WeatherLink
 			services.AddSingleton<IHighLowProcessor, HighLowProcessor>();
 
 			services.AddSingleton<IAPIHttpClient, APIHttpClient>();
-			services.AddSingleton<ISensorFactory, SensorFactory>();
-
 			services.AddSingleton(x => new SensorJsonConverterFactory(x.GetRequiredService<ISensorFactory>()));
 
+			services.AddScoped<ISensorFactory, SensorFactory>();
 			services.AddScoped<IAPIRepository, APIRepository>();
 			services.AddScoped<IClient, Client>();
 			services.AddAllScoped(typeof(ISensorData));


### PR DESCRIPTION
Updated the registration of the `ISensorFactory` service in `IServiceCollectionExtensions.cs` from singleton to scoped. This change ensures a new instance of `ISensorFactory` is created for each request within the scope. Removed the factory registration for `SensorJsonConverterFactory` that relied on the singleton instance.