### PR TITLE
Refactor DI configuration in IServiceCollectionExtensions

### DIFF
--- a/src/myNOC.WeatherLink/IServiceCollectionExtensions.cs
+++ b/src/myNOC.WeatherLink/IServiceCollectionExtensions.cs
@@ -27,10 +27,10 @@ namespace myNOC.WeatherLink
 			services.AddSingleton<IObjectTypeInfoResolver, ObjectTypeInfoResolver>();
 			services.AddSingleton<IHighLowProcessor, HighLowProcessor>();
 
-			services.AddSingleton<IAPIHttpClient, APIHttpClient>();
-			services.AddSingleton(x => new SensorJsonConverterFactory(x.GetRequiredService<ISensorFactory>()));
-
 			services.AddScoped<ISensorFactory, SensorFactory>();
+			services.AddScoped(x => new SensorJsonConverterFactory(x.GetRequiredService<ISensorFactory>()));
+
+			services.AddSingleton<IAPIHttpClient, APIHttpClient>();
 			services.AddScoped<IAPIRepository, APIRepository>();
 			services.AddScoped<IClient, Client>();
 			services.AddAllScoped(typeof(ISensorData));


### PR DESCRIPTION
Updated the dependency injection setup in the `IServiceCollectionExtensions.cs` file. Changed the registration of `SensorJsonConverterFactory` from singleton to scoped, allowing it to be instantiated per request. Retained the singleton registration for `IAPIHttpClient`, which was also moved and re-added for clarity.